### PR TITLE
Use ring for sha256 calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,8 +180,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libcryptsetup-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libcryptsetup-sys = "0.1.2"
 
 
 hex = "0.3.2"
-rust-crypto = "0.2.36"
+ring = "0.13.5"
 failure = "0.1.5"
 rpassword = "4.0.1"
 structopt = "0.3.2"


### PR DESCRIPTION
According to https://rustsec.org/advisories/RUSTSEC-2016-0005.html,
rust-crypto is unmaintained.

Crates depending on rust-crypto should be ported to other crates.

This port replaces rust-crypto with the sha2 implementation of ring,
as fido2luks already depends on it via ctap_hmac. Note that it uses
an old version of ring, so I used the same version, here.

An alternative port to an sha2 implementation from https://github.com/RustCrypto is available at https://github.com/jannic/fido2luks/tree/port-to-rustcrypto