### PR TITLE
Add test case for hash calculations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -170,4 +170,12 @@ mod test {
         assert_eq!("ask".parse::<InputSalt>().unwrap(), InputSalt::AskPassword);
         assert_eq!("lol".parse::<InputSalt>().unwrap(), InputSalt::default());
     }
+
+    #[test]
+    fn input_salt_obtain() {
+        assert_eq!(
+            InputSalt::String("abc".into()).obtain(&PasswordHelper::Stdin).unwrap(),
+            [186, 120, 22, 191, 143, 1, 207, 234, 65, 65, 64, 222, 93, 174, 34, 35, 176, 3, 97, 163, 150, 23, 122, 156, 180, 16, 255, 97, 242, 0, 21, 173]
+        )
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,3 +37,17 @@ fn assemble_secret(hmac_result: &[u8], salt: &[u8]) -> [u8; 32] {
 fn main() -> Fido2LuksResult<()> {
     run_cli()
 }
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_assemble_secret() {
+        assert_eq!(
+            assemble_secret(b"abc", b"def"),
+            [46, 82, 82, 140, 142, 159, 249, 196, 227, 160, 142, 72, 151, 77, 59, 62, 180, 36, 33, 47, 241, 94, 17, 232, 133, 103, 247, 32, 152, 253, 43, 19]
+        )
+    }
+}


### PR DESCRIPTION
While replacing the implementation of sha256, I noticed that there
is no test case actually calling the hash calculations.

Added two such test cases. Please note that I didn't verify that the
result is correct, but just took the value the existing implementation
returned. So those tests will only catch future regressions.