### PR TITLE
use password helper in modified environments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,7 +105,7 @@ pub struct SecretGeneration {
     #[structopt(
         name = "password-helper",
         env = "FIDO2LUKS_PASSWORD_HELPER",
-        default_value = "/usr/bin/systemd-ask-password 'Please enter second factor for LUKS disk encryption!'"
+        default_value = "/usr/bin/env systemd-ask-password 'Please enter second factor for LUKS disk encryption!'"
     )]
     pub password_helper: PasswordHelper,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,7 @@ pub enum PasswordHelper {
 impl Default for PasswordHelper {
     fn default() -> Self {
         PasswordHelper::Script(
-            "/usr/bin/systemd-ask-password 'Please enter second factor for LUKS disk encryption!'"
+            "/usr/bin/env systemd-ask-password 'Please enter second factor for LUKS disk encryption!'"
                 .into(),
         )
     }


### PR DESCRIPTION
Making sure we're not using hard coded path but rather try to ask where to find the binary in the environment. This support Linux distributions such as NixOS.