### PR TITLE
match rp_id to fido2luks

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -33,7 +33,7 @@ pub fn make_credential_id() -> Fido2LuksResult<FidoHmacCredential> {
 pub fn perform_challenge(credential_id: &str, salt: &[u8; 32]) -> Fido2LuksResult<[u8; 32]> {
     let cred = FidoHmacCredential {
         id: hex::decode(credential_id).unwrap(),
-        rp_id: "hmac".to_string(),
+        rp_id: "fido2luks".to_string(),
     };
     let mut errs = Vec::new();
     match get_devices()? {


### PR DESCRIPTION
Make sure to match the ``rp_id`` matches the one provided by e7049a281a63e3f72f83b720eb44ccb0c65ed4e1.