### PR TITLE
Add new option --pin-input to pass the authenticator pin value  in cli

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,7 +95,7 @@ impl AuthenticatorParameters {
     fn read_pin(&self) -> Fido2LuksResult<String> {
         if let Some(pass) = self.pin_input.as_ref() {
             println!("pin : {}", pass);
-            Ok(pass)
+            Ok(pass.to_string())
         } else {
             util::read_password("Authenticator PIN", false)
         }
@@ -373,7 +373,7 @@ pub fn run_cli() -> Fido2LuksResult<()> {
         } => {
             let pin_string;
             let pin = if authenticator.pin {
-                pin_string = read_pin()?;
+                pin_string = authenticator.read_pin()?;
                 Some(pin_string.as_ref())
             } else {
                 None
@@ -417,7 +417,7 @@ pub fn run_cli() -> Fido2LuksResult<()> {
             ..
         } => {
             let pin = if authenticator.pin {
-                Some(read_pin()?)
+                Some(authenticator.read_pin()?)
             } else {
                 None
             };
@@ -533,7 +533,7 @@ pub fn run_cli() -> Fido2LuksResult<()> {
         } => {
             let pin_string;
             let pin = if authenticator.pin {
-                pin_string = read_pin()?;
+                pin_string = authenticator.read_pin()?;
                 Some(pin_string.as_ref())
             } else {
                 None

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,6 +91,17 @@ pub struct AuthenticatorParameters {
     pub await_time: u64,
 }
 
+impl AuthenticatorParameters {
+    fn read_pin(&self) -> Fido2LuksResult<String> {
+        if let Some(pass) = self.pin_input.as_ref() {
+            println!("pin : {}", pass);
+            Ok(pass)
+        } else {
+            util::read_password("Authenticator PIN", false)
+        }
+    }
+}
+
 #[derive(Debug, StructOpt)]
 pub struct LuksParameters {
     #[structopt(env = "FIDO2LUKS_DEVICE")]
@@ -334,15 +345,6 @@ pub fn parse_cmdline() -> Args {
     Args::from_args()
 }
 
-fn read_pin() -> Fido2LuksResult<String> {
-    if let Some(pass) = authenticator.pin_input.as_ref() {
-        println!("pin : {}", pass)
-        Ok(pass)
-    } else {
-        util::read_password("Authenticator PIN", false)
-    }
-}
-
 pub fn run_cli() -> Fido2LuksResult<()> {
     let mut stdout = io::stdout();
     let args = parse_cmdline();
@@ -354,7 +356,7 @@ pub fn run_cli() -> Fido2LuksResult<()> {
         } => {
             let pin_string;
             let pin = if authenticator.pin {
-                pin_string = read_pin()?;
+                pin_string = authenticator.read_pin()?;
                 Some(pin_string.as_ref())
             } else {
                 None

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,10 @@ pub struct AuthenticatorParameters {
     #[structopt(short = "P", long = "pin")]
     pub pin: bool,
 
+    /// Pass PIN value in CLI argument
+    #[structopt(long = "pin-input", name = "pin-input")]
+    pub pin_input: Option<String>,
+
     /// Await for an authenticator to be connected, timeout after n seconds
     #[structopt(
         long = "await-dev",
@@ -163,10 +167,6 @@ fn derive_secret(
         perform_challenge(&credentials, salt, timeout - start.elapsed().unwrap(), pin)?;
 
     Ok((sha256(&[salt, &unsalted[..]]), cred.clone()))
-}
-
-fn read_pin() -> Fido2LuksResult<String> {
-    util::read_password("Authenticator PIN", false)
 }
 
 #[derive(Debug, StructOpt)]
@@ -332,6 +332,15 @@ pub enum TokenCommand {
 
 pub fn parse_cmdline() -> Args {
     Args::from_args()
+}
+
+fn read_pin() -> Fido2LuksResult<String> {
+    if let Some(pass) = authenticator.pin_input.as_ref() {
+        println!("pin : {}", pass)
+        Ok(pass)
+    } else {
+        util::read_password("Authenticator PIN", false)
+    }
 }
 
 pub fn run_cli() -> Fido2LuksResult<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,7 +94,6 @@ pub struct AuthenticatorParameters {
 impl AuthenticatorParameters {
     fn read_pin(&self) -> Fido2LuksResult<String> {
         if let Some(pass) = self.pin_input.as_ref() {
-            println!("pin : {}", pass);
             Ok(pass.to_string())
         } else {
             util::read_password("Authenticator PIN", false)


### PR DESCRIPTION
@shimunn 

Refer: #14 

Added new option --pin-input to pass the authenticator pin value in cli. I don't have any prior rust experience, so feedback welcome :) 