### PR TITLE
added: pin-helper option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,7 +106,14 @@ pub fn get_input(
             authenticator.pin && may_require_pin()?,
             authenticator.pin_prefixed,
         ) {
-            (true, false) => (Some(read_pin()?), salt.obtain_sha256(password_helper)?),
+            (true, false) => {
+                let pin = if let Some(ref pin_helper) = authenticator.pin_helper {
+                    pin_helper.obtain()
+                } else {
+                    read_pin()
+                };
+                (Some(pin?), salt.obtain_sha256(password_helper)?)
+            }
             (true, true) => read_password_pin_prefixed(|| {
                 salt.obtain(password_helper).and_then(|secret| {
                     String::from_utf8(secret).map_err(|e| Fido2LuksError::from(e))

--- a/src/cli_args/mod.rs
+++ b/src/cli_args/mod.rs
@@ -80,6 +80,11 @@ pub struct AuthenticatorParameters {
     #[structopt(short = "P", long = "pin")]
     pub pin: bool,
 
+    /// Script to be called to retrive the authenticator PIN
+    /// {n}Will be ignored if `pin-prefixed` is set
+    #[structopt(name = "pin-helper", long = "pin-helper", env = "FIDO2LUKS_PIN_HELPER")]
+    pub pin_helper: Option<PasswordHelper>,
+
     /// Request PIN and password combined `pin:password` when using an password helper
     #[structopt(long = "pin-prefixed")]
     pub pin_prefixed: bool,
@@ -134,7 +139,7 @@ pub struct SecretParameters {
         default_value = "ask"
     )]
     pub salt: SecretInput,
-    /// Script used to obtain passwords, overridden by --interactive flag
+    /// Script to be used to obtain passwords, overridden by --interactive flag
     #[structopt(
         name = "password-helper",
         env = "FIDO2LUKS_PASSWORD_HELPER",


### PR DESCRIPTION
Addresses #43 

@MkfsSion would you mind testing this, as I don't have an PIN protected key around atm.

Usage should be as follows: 

```
fido2luks open /dev/nvme1n1p1 --pin --password-helper 'bash -c "echo 123456"' --pin-helper 'bash -c "echo 1234"' test
```