### PR TITLE
allow piped PIN input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ name = "fido2luks"
 version = "0.3.1-alpha"
 dependencies = [
  "anyhow",
+ "atty",
  "ctap-hid-fido2",
  "failure",
  "hex 0.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_derive = "1.0.116"
 serde = "1.0.116"
 anyhow = "1.0.56"
 ctap-hid-fido2 = "3.4.1"
+atty = "0.2"
 
 [build-dependencies]
 hex = "0.3.2"
@@ -34,6 +35,7 @@ rpassword = "4.0.1"
 libcryptsetup-rs = "0.9.1"
 structopt = "0.3.2"
 anyhow = "1.0.56"
+atty = "0.2"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
allow piped PIN input as prior to --pin-source /dev/stdin which is used by saravanan30erd/solokey-full-disk-encryption see https://github.com/saravanan30erd/solokey-full-disk-encryption/issues/12